### PR TITLE
Document statsd to loggregator behavior

### DIFF
--- a/uaa-metrics.html.md.erb
+++ b/uaa-metrics.html.md.erb
@@ -32,6 +32,7 @@ Each table depicts the following information:
 * **Indicator**: A discussion of what changes in the metric's value may indicate over time.
 * **Status**: **Active** metrics may change between metrics emissions, whereas **static** metrics are fixed and do not change.
 
+Note: If consuming UAA metrics via the Cloud Foundry Firehose, incremental metrics (i.e., metrics that capture an increment or decrement in a value since last emission) will be expressed instead as cumulative values. See [statsd-injector](https://github.com/cloudfoundry/statsd-injector) for details.
 
 ### <a id="global"></a>Global Performance Metrics
 

--- a/uaa-metrics.html.md.erb
+++ b/uaa-metrics.html.md.erb
@@ -9,13 +9,15 @@ table.nice code {
 }
 </style>
 
+
 ## <a id="intro"></a> Introduction
 
 User Account and Authentication (UAA) emits metrics constantly. These metrics can help you understand performance over time, troubleshoot problems, and asses the health of your installation in real-time. These metrics are emitted through Loggregator.
 
 This topic describes different metrics that UAA, virtual machines (VMs), and Java Virtual Machines (JVMs) emit.
 
-## <a id="performance"></a>Understanding UAA Performance
+
+## <a id="performance"></a> Understanding UAA Performance
 
 These tables explain different types of UAA and UAA-related metrics you can view. There are three different metric areas discussed in the following tables:
 
@@ -32,9 +34,9 @@ Each table depicts the following information:
 * **Indicator**: A discussion of what changes in the metric's value may indicate over time.
 * **Status**: **Active** metrics may change between metrics emissions, whereas **static** metrics are fixed and do not change.
 
-Note: If consuming UAA metrics via the Cloud Foundry Firehose, incremental metrics (i.e., metrics that capture an increment or decrement in a value since last emission) will be expressed instead as cumulative values. See [statsd-injector](https://github.com/cloudfoundry/statsd-injector) for details.
+<p class='note'><strong>Note:</strong> If consuming UAA metrics through the Firehose, incremental metrics (i.e., metrics that capture an increment or decrement in a value since last emission) will be expressed as cumulative values. For more information, see [statsd-injector](https://github.com/cloudfoundry/statsd-injector).</p>
 
-### <a id="global"></a>Global Performance Metrics
+### <a id="global"></a> Global Performance Metrics
 
 This section describes metrics that UAA emits.
 
@@ -151,11 +153,12 @@ This section describes metrics that UAA emits.
 	</tr>	
 </table>
 
-## <a id="vitals"></a>Understanding UAA Vitals
+
+## <a id="vitals"></a> Understanding UAA Vitals
 
 This section describes metrics that the UAA VM and JVM emit.
 
-### <a id="vm-vitals"></a>Virtual Machine Vitals
+### <a id="vm-vitals"></a> Virtual Machine Vitals
 
 <table class="nice">
 	<th>Name</th>
@@ -214,7 +217,7 @@ This section describes metrics that the UAA VM and JVM emit.
 	</tr>
 </table>
 
-### <a id="jvm-vitals"></a>Java Virtual Machine Vitals
+### <a id="jvm-vitals"></a> Java Virtual Machine Vitals
 
 <table class="nice">
 	<th>Name</th>


### PR DESCRIPTION
This was confusing to me earlier, since the docs refer to incremental metrics while the firehose emits cumulative metrics. Let me know if this language is unclear--happy to revise.