### PR TITLE
note when scopes take affect from ext group map

### DIFF
--- a/uaa-user-management.html.md.erb
+++ b/uaa-user-management.html.md.erb
@@ -184,7 +184,7 @@ UAAC stores the token in `~/.uaac.yml`.
     * [Grant Admin Permissions for LDAP](#grant-admin-ldap)
     * [Grant Admin Permissions for SAML](#grant-admin-saml)
 
-*Note: UAA will not grant scopes from external group mappings until the next time a user in the external group logs in. This means that in order for the mapping to take affect, users granted scopes from external group mapping will need to logout and login again.*
+<p class="note"><strong>Note</strong>: The UAA will not grant scopes for users in external groups until the next time the user logs in. This means that users granted scopes from external group mappings must log out from PCF and log back in before their new scope takes effect.</p>
 
 ### <a id='grant-admin-ldap'></a> Grant Admin Permissions for LDAP
 

--- a/uaa-user-management.html.md.erb
+++ b/uaa-user-management.html.md.erb
@@ -184,6 +184,8 @@ UAAC stores the token in `~/.uaac.yml`.
     * [Grant Admin Permissions for LDAP](#grant-admin-ldap)
     * [Grant Admin Permissions for SAML](#grant-admin-saml)
 
+*Note: UAA will not grant scopes from external group mappings until the next time a user in the external group logs in. This means that in order for the mapping to take affect, users granted scopes from external group mapping will need to logout and login again.*
+
 ### <a id='grant-admin-ldap'></a> Grant Admin Permissions for LDAP
 
 Run the commands below to grant all users under the mapped LDAP Group admin permissions. Replace `GROUP-DISTINGUISHED-NAME` with an appropriate group name. 


### PR DESCRIPTION
When external groups are mapped to UAA groups the scopes that those
groups grant do not take affect until the user logs out and logs back
in.