### PR TITLE
Remove reference to unsupported database

### DIFF
--- a/uaa-overview.html.md.erb
+++ b/uaa-overview.html.md.erb
@@ -35,7 +35,7 @@ The major features of UAA include the following:
 		<li>Push as an app to Cloud Foundry</li>
 	</ul>
 	</li>
-	<li>Database flexibility, including support for MySQL, Postgres, and SQL Server</li>
+	<li>Database flexibility, including support for MySQL and Postgres</li>
 	<li>Auditing, logging, and monitoring</li>
 	<li>Token exchange for SAML and JWT bearers</li>
 	<li><a href="https://docs.cloudfoundry.org/api/uaa/index.html">Rest APIs</a> for authentication, authorization, and configuration management</li>


### PR DESCRIPTION
UAA no longer supports SQL Server, so it should not be listed as a supported DB.